### PR TITLE
Sort TC36K matrix by physical columns, then rows (Qwerty QAZ first)

### DIFF
--- a/boards/shields/tc36k/README.md
+++ b/boards/shields/tc36k/README.md
@@ -11,29 +11,28 @@ for background, although the final pin selection and trace routing changed).
 
 ![Partial Tutte-Coxeter Graph (26/30 vertices, 36/45 edges)](https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhvS5QfAl7YotptMtpu0nG8XOHOsqG2vocUFF2sRgrn_QwAcUQNhDkctHt_42rQor3Bb5tbAW6FiOsYqv2craP086HMTuAqWk9U0A4yOeEsQkhyphenhyphenUxoayJWf5e-N3_Jg1TC1p9YAiVPTK02pEVCUu3hl72REIk5BAjXgZGoF7T-NWQ28iRirwFs6yzFzAe0/w200-h194/Screenshot%202025-05-28%20at%2014.59.35.png)
 
-This matrix shows the full 15×15 Tutte-Coxeter bipartite scanning matrix with the
-two unused rows and columns last (❌), and the further 9 keys this would allow (⭕)
-if using 30 GPIOs rather than just 26 for a 13×13 scanning matrix. The allocation
-of keys to matrix elements and scanning matrix rows and columns to GPIO pins was
-arbitrary and down to how easy it was to layout the PCB traces:
+This matrix shows the 13×13 partial Tutte-Coxeter bipartite scanning matrix
+in the physical column order (QAZ colunm first) with rows sorted to ensure Q
+is top left as the first matrix entry. If using the full matrix this would
+be 15x15 using 30 GPIOs and have another 9 keys making 45 in all.
+The allocation of keys to matrix elements and scanning matrix rows and columns
+to GPIO pins was arbitrary and down to how easy it was to layout the PCB traces:
 
-| GP | 11 | 10 | 3 | 4 | 7 | 26 | 27 | 28 | 15 | 21 | 19 | 20 | 16 | ❌ | ❌ |
-|---:|:--:|:--:|:-:|:-:|:-:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| 12 |  / |    |   |   |   |    |  F |    |    |    |    |    |    |    | ⭕ |
-| 8  |  P |  L |   |   |   |    |    |    |    |    |    |  A |    |    |    |
-| 9  |    |  . | , |   |   |    |    |    |    |    |    |    |    | ⭕ |    |
-| 1  |    |    | K | U |   |    |    |    |    |  W |    |    |    |    |    |
-| 6  |    |    |   | M | H |    |    |    |    |    |    |    |    |    | ⭕ |
-| 2  |    |  O |   |   | Y |  T |    |    |    |    |    |    |    |    |    |
-| 22 |    |    |   |   |   |  G |  V |    |    |    |    |    | L1 |    |    |
-| 0  |    |    | I |   |   |    |  R |  E |    |    |    |    |    |    |    |
-| 13 |    |    |   |   | N |    |    |  D | R2 |    |    |    |    |    |    |
-| 14 |  ; |    |   |   |   |    |    |    | R3 |  S |    |    |    |    |    |
-| 18 |    |    |   |   |   |  B |    |    |    |  X | L2 |    |    |    |    |
-| 17 |    |    |   |   |   |    |    |  C |    |    | L3 |  Z |    |    |    |
-| 5  |    |    |   | J |   |    |    |    |    |    |    |  Q | R1 |    |    |
-| ❌ |    |    |   |   |   |    |    |    | ⭕ |    |    |    | ⭕  | ⭕ |    |
-| ❌ |    |    |   |   |   |    |    |    |    |    | ⭕ |    |    | ⭕  | ⭕ |
+| GP | 20 | 21 | 28 | 27 | 26 | 19 | 16 | 15 | 7 | 4 | 3 | 10 | 11 |
+|---:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:-:|:-:|:-:|:--:|:--:|
+| 5  | Q  |    |    |    |    |    | R1 |    |   | J |   |    |    |
+| 8  | A  |    |    |    |    |    |    |    |   |   |   | L  | P  |
+| 17 | Z  |    | C  |    |    | L3 |    |    |   |   |   |    |    |
+| 1  |    | W  |    |    |    |    |    |    |   | U | K |    |    |
+| 14 |    | S  |    |    |    |    |    | R3 |   |   |   |    | ;  |
+| 18 |    | X  |    |    | B  | L2 |    |    |   |   |   |    |    |
+| 0  |    |    | E  | R  |    |    |    |    |   |   | I |    |    |
+| 13 |    |    | D  |    |    |    |    | R2 | N |   |   |    |    |
+| 12 |    |    |    | F  |    |    |    |    |   |   |   |    | /  |
+| 22 |    |    |    | V  | G  |    | L1 |    |   |   |   |    |    |
+| 2  |    |    |    |    | T  |    |    |    | Y |   |   | O  |    |
+| 6  |    |    |    |    |    |    |    |    | H | M |   |    |    |
+| 9  |    |    |    |    |    |    |    |    |   |   | , | .  |    |
 
 The keys here are labeled as per Qwerty, with L3, L2, L1, R1, R2, and R3 for the thumbs:
 

--- a/boards/shields/tc36k/tc36k.overlay
+++ b/boards/shields/tc36k/tc36k.overlay
@@ -15,35 +15,35 @@
         wakeup-source;
 
         col-gpios
-            = <&pico_header 11 GPIO_OPEN_SOURCE>
-            , <&pico_header 10 GPIO_OPEN_SOURCE>
-            , <&pico_header 3 GPIO_OPEN_SOURCE>
-            , <&pico_header 4 GPIO_OPEN_SOURCE>
-            , <&pico_header 7 GPIO_OPEN_SOURCE>
-            , <&pico_header 26 GPIO_OPEN_SOURCE>
-            , <&pico_header 27 GPIO_OPEN_SOURCE>
-            , <&pico_header 28 GPIO_OPEN_SOURCE>
-            , <&pico_header 15 GPIO_OPEN_SOURCE>
+            = <&pico_header 20 GPIO_OPEN_SOURCE>
             , <&pico_header 21 GPIO_OPEN_SOURCE>
+            , <&pico_header 28 GPIO_OPEN_SOURCE>
+            , <&pico_header 27 GPIO_OPEN_SOURCE>
+            , <&pico_header 26 GPIO_OPEN_SOURCE>
             , <&pico_header 19 GPIO_OPEN_SOURCE>
-            , <&pico_header 20 GPIO_OPEN_SOURCE>
             , <&pico_header 16 GPIO_OPEN_SOURCE>
+            , <&pico_header 15 GPIO_OPEN_SOURCE>
+            , <&pico_header 7 GPIO_OPEN_SOURCE>
+            , <&pico_header 4 GPIO_OPEN_SOURCE>
+            , <&pico_header 3 GPIO_OPEN_SOURCE>
+            , <&pico_header 10 GPIO_OPEN_SOURCE>
+            , <&pico_header 11 GPIO_OPEN_SOURCE>
             ;
 
         row-gpios
-            = <&pico_header 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            = <&pico_header 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pico_header 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pico_header 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 22 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pico_header 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pico_header 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pico_header 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 22 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pico_header 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
 };
@@ -54,10 +54,10 @@
         columns = <13>;
         rows = <13>;
         map = <
-            RC(12,11) RC(3,9)  RC(7,7)   RC(7,6)   RC(5,5)  RC(5,4)   RC(3,3)  RC(7,2) RC(5,1) RC(1,0)
-            RC(1,11)  RC(9,9)  RC(8,7)   RC(0,6)   RC(6,5)  RC(4,4)   RC(12,3) RC(3,2) RC(1,1) RC(9,0)
-            RC(11,11) RC(10,9) RC(11,7)  RC(6,6)   RC(10,5) RC(8,4)   RC(4,3)  RC(2,2) RC(2,1) RC(0,0)
-                               RC(11,10) RC(10,10) RC(6,12) RC(12,12) RC(8,8)  RC(9,8)
+            RC(0,0) RC(3,1) RC(6,2) RC(6,3) RC(10,4) RC(10,8) RC(3,9)  RC(6,10)  RC(10,11) RC(1,12)
+            RC(1,0) RC(4,1) RC(7,2) RC(8,3) RC(9,4)  RC(11,8) RC(0,9)  RC(3,10)  RC(1,11)  RC(4,12)
+            RC(2,0) RC(5,1) RC(2,2) RC(9,3) RC(5,4)  RC(7,8)  RC(11,9) RC(12,10) RC(12,11) RC(8,12)
+                            RC(2,5) RC(5,5) RC(9,6)  RC(0,6)  RC(7,7)  RC(4,7)
         >;
     };
 };


### PR DESCRIPTION
This makes the first entry in the matrix (top-left) Qwerty 'Q' as conventional for a 36-key layout like this. It also makes comparison to the Hesse matrix easier.

Note there are three scanning columns for the six thumb keys, only two keys each, making 13 scanning columns in total.

Also note that not all the columns have their three keys in the physical order, eg CED rather than EDC for the third column.

Sadly this hides the elegance of the matrix which hints at the graph symmetries.