### PR TITLE
HID LED on Raspberry Pi Pico controller keyboards with GP25 user LED

### DIFF
--- a/boards/shields/slump52/slump52.overlay
+++ b/boards/shields/slump52/slump52.overlay
@@ -5,8 +5,28 @@
  */
 
 #include <dt-bindings/zmk/matrix_transform.h>
+#include <dt-bindings/zmk/hid_indicators.h>
 #include <physical_layouts.dtsi>
 #include "slump52-layouts.dtsi"
+
+/ {
+    leds {
+        compatible = "gpio-leds";
+
+        hid_led: hid_led {
+            gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+        };
+    };
+
+    indicators {
+        compatible = "zmk,indicator-leds";
+
+        hid_indicator: hid_indicator {
+            indicator = <(HID_INDICATOR_NUM_LOCK | HID_INDICATOR_CAPS_LOCK | HID_INDICATOR_SCROLL_LOCK | HID_INDICATOR_COMPOSE | HID_INDICATOR_KANA)>;
+            leds = <&hid_led>;
+        };
+    };
+};
 
 / {
     kscan0: kscan0 {

--- a/boards/shields/tc36k/tc36k.overlay
+++ b/boards/shields/tc36k/tc36k.overlay
@@ -5,8 +5,28 @@
  */
 
 #include <dt-bindings/zmk/matrix_transform.h>
+#include <dt-bindings/zmk/hid_indicators.h>
 #include <physical_layouts.dtsi>
 #include "tc36k-layouts.dtsi"
+
+/ {
+    leds {
+        compatible = "gpio-leds";
+
+        hid_led: hid_led {
+            gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+        };
+    };
+
+    indicators {
+        compatible = "zmk,indicator-leds";
+
+        hid_indicator: hid_indicator {
+            indicator = <(HID_INDICATOR_NUM_LOCK | HID_INDICATOR_CAPS_LOCK | HID_INDICATOR_SCROLL_LOCK | HID_INDICATOR_COMPOSE | HID_INDICATOR_KANA)>;
+            leds = <&hid_led>;
+        };
+    };
+};
 
 / {
     kscan0: kscan0 {

--- a/build.yaml
+++ b/build.yaml
@@ -28,10 +28,10 @@ include:
     shield: slump52
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: rpi_pico2/rp2350a/m33
-    shield: slump52
-    snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+#  - board: rpi_pico2/rp2350a/m33
+#    shield: slump52
+#    snippet: studio-rpc-usb-uart
+#    cmake-args: -DCONFIG_ZMK_STUDIO=y
   # Bivouac34 (RP2040-Zero):
   - board: rpi_pico//zmk
     shield: bivouac34


### PR DESCRIPTION
See https://github.com/zmkfirmware/zmk/pull/3239 - this is new in what will be ZMK v0.4

I already use the Raspberry Pi Pico's user LED on GPIO 25 for Caps Lock in QMK, but showing any of the five HID states seems useful.

Tested with https://github.com/damieng/setledsmac