### PR TITLE
Zephyr deprecating kscan: kscan-gpio-matrix -> input-gpio-matrix

### DIFF
--- a/boards/shields/acid/acid.dtsi
+++ b/boards/shields/acid/acid.dtsi
@@ -9,7 +9,7 @@
 
 / {
     chosen {
-        zmk,kscan = &kscan0;
+        zmk,matrix-input = &matrix;
         zmk,physical-layout = &default_layout;
     };
 };
@@ -24,8 +24,8 @@
  */
 
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 

--- a/boards/shields/bivouac34/bivouac34-layouts.dtsi
+++ b/boards/shields/bivouac34/bivouac34-layouts.dtsi
@@ -40,7 +40,7 @@
         compatible = "zmk,physical-layout";
         display-name = "34-keys";
 
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform34>;
 
         keys  //                     w   h    x    y     rot    rx    ry
@@ -85,7 +85,7 @@
         compatible = "zmk,physical-layout";
         display-name = "32-key";
 
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform32>;
 
         keys  //                     w   h    x    y     rot    rx    ry

--- a/boards/shields/bivouac34/bivouac34.overlay
+++ b/boards/shields/bivouac34/bivouac34.overlay
@@ -9,8 +9,8 @@
 #include "bivouac34-layouts.dtsi"
 
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 

--- a/boards/shields/bivvy16d/boards/rpi_pico.overlay
+++ b/boards/shields/bivvy16d/boards/rpi_pico.overlay
@@ -40,7 +40,7 @@
 
 / {
     chosen {
-        zmk,kscan = &kscan0;
+        zmk,matrix-input = &matrix;
         zmk,physical-layout = &bivvy16d_L16_R16_layout;
         zmk,split-uart = &uart0;
         // Other chosen items
@@ -50,8 +50,8 @@
      * so can define the GPIOs once centrally.
      */
 
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 

--- a/boards/shields/fly_half/fly_half-layouts.dtsi
+++ b/boards/shields/fly_half/fly_half-layouts.dtsi
@@ -40,7 +40,7 @@
         compatible = "zmk,physical-layout";
         display-name = "LAYOUT";
 
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform30>;
 
         keys  //                     w   h    x    y     rot    rx    ry
@@ -80,7 +80,7 @@
 
 / {
     chosen {
-        zmk,kscan = &kscan0;
+        zmk,matrix-input = &matrix;
         zmk,physical-layout = &physical_layout30;
     };
 };

--- a/boards/shields/fly_half/fly_half_left.overlay
+++ b/boards/shields/fly_half/fly_half_left.overlay
@@ -8,8 +8,8 @@
 
 /* The GPIO pins are the same left and right, but in different order */
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-direct";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-direct";
         wakeup-source;
         input-gpios
             /* Left hand top row, pinky to inner column */

--- a/boards/shields/fly_half/fly_half_right.overlay
+++ b/boards/shields/fly_half/fly_half_right.overlay
@@ -8,8 +8,8 @@
 
 /* The GPIO pins are the same left and right, but in different order */
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-direct";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-direct";
         wakeup-source;
         input-gpios
             /* Right hand top row, pinky to inner column */

--- a/boards/shields/goldilocks32/goldilocks32-layouts.dtsi
+++ b/boards/shields/goldilocks32/goldilocks32-layouts.dtsi
@@ -57,7 +57,7 @@
         compatible = "zmk,physical-layout";
         display-name = "32-keys";
 
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform32>;
         keys  //                     w   h    x    y     rot    rx    ry
             = <&key_physical_attrs 100 140   36   33    1000    86    83>
@@ -104,7 +104,7 @@
         compatible = "zmk,physical-layout";
         display-name = "30-key";
 
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform30>;
 
         keys  //                     w   h    x    y     rot    rx    ry

--- a/boards/shields/goldilocks32/goldilocks32.overlay
+++ b/boards/shields/goldilocks32/goldilocks32.overlay
@@ -29,8 +29,8 @@
 };
 
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 

--- a/boards/shields/hesse/hesse.overlay
+++ b/boards/shields/hesse/hesse.overlay
@@ -14,8 +14,8 @@
  * Those are P1.01, P1.02, and P1.07 - referenced here via their &gpio1 names.
  */
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 
@@ -66,7 +66,7 @@
     physical_layout0: physical_layout_0 { // First physical layout, use different naming for other layouts
         compatible = "zmk,physical-layout";
         display-name = "Default Layout";
-        kscan = <&kscan0>; // Label of the kscan node, optional if all layouts use the same
+        input = <&matrix>; // optional if all layouts use the same
         transform = <&default_transform>; // Label of the matrix transform for this layout
     };
 };

--- a/boards/shields/rugby_union/rugby_union-layouts.dtsi
+++ b/boards/shields/rugby_union/rugby_union-layouts.dtsi
@@ -40,7 +40,7 @@
         compatible = "zmk,physical-layout";
         display-name = "LAYOUT";
 
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform30>;
 
         keys  //                     w   h    x    y     rot    rx    ry

--- a/boards/shields/rugby_union/rugby_union.overlay
+++ b/boards/shields/rugby_union/rugby_union.overlay
@@ -9,8 +9,8 @@
 #include "rugby_union-layouts.dtsi"
 
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 

--- a/boards/shields/slump52/slump52-layouts.dtsi
+++ b/boards/shields/slump52/slump52-layouts.dtsi
@@ -4,7 +4,7 @@
     physical_layout0: physical_layout_0 {
         compatible = "zmk,physical-layout";
         display-name = "LAYOUT";
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform0>;
 
         keys  //                     w   h    x    y     rot    rx    ry

--- a/boards/shields/slump52/slump52.overlay
+++ b/boards/shields/slump52/slump52.overlay
@@ -29,8 +29,8 @@
 };
 
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 
@@ -96,7 +96,7 @@
     physical_layout0: physical_layout_0 { // First physical layout, use different naming for other layouts
         compatible = "zmk,physical-layout";
         display-name = "Default Layout";
-        kscan = <&kscan0>; // Label of the kscan node, optional if all layouts use the same
+        input = <&matrix>; // optional if all layouts use the same
         transform = <&default_transform>; // Label of the matrix transform for this layout
     };
 };

--- a/boards/shields/tc36k/tc36k-layouts.dtsi
+++ b/boards/shields/tc36k/tc36k-layouts.dtsi
@@ -5,7 +5,7 @@
         compatible = "zmk,physical-layout";
         display-name = "Default";
 
-        kscan = <&kscan0>;
+        input = <&matrix>;
         transform = <&matrix_transform0>;
 
         keys  //                     w   h    x    y     rot    rx    ry

--- a/boards/shields/tc36k/tc36k.overlay
+++ b/boards/shields/tc36k/tc36k.overlay
@@ -29,8 +29,8 @@
 };
 
 / {
-    kscan0: kscan0 {
-        compatible = "zmk,kscan-gpio-matrix";
+    matrix: matrix {
+        compatible = "zmk,input-gpio-matrix";
         diode-direction = "col2row";
         wakeup-source;
 
@@ -86,7 +86,7 @@
     physical_layout0: physical_layout_0 { // First physical layout, use different naming for other layouts
         compatible = "zmk,physical-layout";
         display-name = "Default Layout";
-        kscan = <&kscan0>; // Label of the kscan node, optional if all layouts use the same
+        input = <&matrix>; // optional if all layouts use the same
         transform = <&default_transform>; // Label of the matrix transform for this layout
     };
 };


### PR DESCRIPTION
And kscan-gpio-direct -> input-gpio-direct